### PR TITLE
support python 3 using octoprint >= 1.4  (#690)

### DIFF
--- a/_plugins/preprintservice.md
+++ b/_plugins/preprintservice.md
@@ -36,7 +36,9 @@ compatibility:
   - linux
   - windows
   - macos
-
+  
+  python: ">=2.7,<4"
+  
 ---
 
 # OctoPrint-PrePrintService


### PR DESCRIPTION
* Python 3 support

* support python 3, octoprint >= 1.4

* support python 3, octoprint = 1.3, 1.4

* removed octoprint version 1.4.0